### PR TITLE
fix/sdk-issues-in-annotation-queue

### DIFF
--- a/python/fi/api/auth.py
+++ b/python/fi/api/auth.py
@@ -29,7 +29,7 @@ class ResponseHandler(Generic[T, U], ABC):
     @classmethod
     def parse(cls, response: Response) -> Union[T, U]:
         """Parse the response into the expected type"""
-        if not response.ok or response.status_code != 200:
+        if not (200 <= response.status_code < 300):
             cls._handle_error(response)
         return cls._parse_success(response)
 

--- a/python/fi/queues/client.py
+++ b/python/fi/queues/client.py
@@ -719,7 +719,7 @@ class AnnotationQueue(APIKeyAuth):
             For JSON format: list of dicts. For CSV: raw text content.
         """
         _validate_id(queue_id, "queue_id")
-        params: Dict[str, Any] = {"format": export_format}
+        params: Dict[str, Any] = {"export_format": export_format}
         if status:
             params["status"] = status
 

--- a/python/fi/queues/types.py
+++ b/python/fi/queues/types.py
@@ -56,7 +56,7 @@ class QueueAnalytics(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
-    throughput: Optional[List[Dict[str, Any]]] = None
+    throughput: Optional[Dict[str, Any]] = None
     annotator_performance: Optional[List[Dict[str, Any]]] = Field(None, alias="annotatorPerformance")
     label_distribution: Optional[Dict[str, Any]] = Field(None, alias="labelDistribution")
     status_breakdown: Optional[Dict[str, int]] = Field(None, alias="statusBreakdown")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "futureagi"
-version = "0.6.11"
+version = "0.6.12"
 description = "We help GenAI teams maintain high-accuracy for their Models in production."
 authors = ["Future AGI <no-reply@futureagi.com>"]
 readme = "README.md"

--- a/typescript/futureagi/package.json
+++ b/typescript/futureagi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@future-agi/sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "We help GenAI teams maintain high-accuracy for their Models in production.",
   "type": "module",
   "main": "./dist/esm/index.js",

--- a/typescript/futureagi/src/api/auth.ts
+++ b/typescript/futureagi/src/api/auth.ts
@@ -23,7 +23,7 @@ export abstract class ResponseHandler<T = any, U = any> {
      * Parse the response into the expected type
      */
     static parse<T, U>(response: AxiosResponse, handlerClass: typeof ResponseHandler): T | U {
-        if (!response || response.status !== 200) {
+        if (!response || response.status < 200 || response.status >= 300) {
             handlerClass._handleError(response);
         }
         return handlerClass._parseSuccess(response);

--- a/typescript/futureagi/src/queues/client.ts
+++ b/typescript/futureagi/src/queues/client.ts
@@ -718,7 +718,7 @@ export class AnnotationQueue extends APIKeyAuth {
         options?: { format?: 'json' | 'csv'; status?: string; timeout?: number },
     ): Promise<string | Record<string, any>[]> {
         const fmt = options?.format ?? 'json';
-        const params: Record<string, any> = { format: fmt };
+        const params: Record<string, any> = { export_format: fmt };
         if (options?.status) params.status = options.status;
 
         const requestConfig: RequestConfig = {

--- a/typescript/futureagi/src/queues/types.ts
+++ b/typescript/futureagi/src/queues/types.ts
@@ -120,7 +120,7 @@ export interface QueueProgress {
 }
 
 export interface QueueAnalytics {
-    throughput?: Array<Record<string, any>>;
+    throughput?: Record<string, any>;
     annotatorPerformance?: Array<Record<string, any>>;
     labelDistribution?: Record<string, any>;
     statusBreakdown?: Record<string, number>;


### PR DESCRIPTION
# Pull Request

Fix annotation queue SDK issues

  Changes:
  - fi/api/auth.py:32 — Accept all 2xx status codes (200 <= status < 300) instead of only 200
  - fi/queues/types.py:59 — Fix throughput type from List[Dict] to Dict to match API response
  - fi/queues/client.py:722 — Use export_format query param instead of format to avoid DRF content negotiation collision

## Checklist
- [ ] Code compiles correctly.
- [ ] Created/updated tests.
- [ ] Linting and formatting applied.
- [ ] Documentation updated.

## Related Issues
Closes TH-3476
