### PR TITLE
fix: custom eval resolution for evalId=0 and camelCase keys (TH-3610)

### DIFF
--- a/python/fi/datasets/dataset.py
+++ b/python/fi/datasets/dataset.py
@@ -548,25 +548,40 @@ class Dataset(APIKeyAuth):
             response_handler=EvalInfoResponseHandler,
         )
         eval_id = None
+        matched_eval = None
         if isinstance(all_evals, list):
             for ev in all_evals:
                 if ev.get("name", "").lower() == eval_template.lower():
-                    eval_id = ev.get("evalId") or ev.get("eval_id")
-                    break
-        if not eval_id:
+                    candidate_id = ev.get("evalId") if ev.get("evalId") is not None else ev.get("eval_id")
+                    if candidate_id is not None:
+                        eval_id = candidate_id
+                        matched_eval = ev
+                        break
+        if eval_id is None:
             available = sorted({ev.get("name", "") for ev in all_evals}) if isinstance(all_evals, list) else []
             raise DatasetValidationError(
                 f"Unknown template: '{eval_template}'. Available: {available}"
             )
 
-        url = f"{self._base_url}/sdk/api/v1/eval/{eval_id}/"
-        template_details = self.request_with_retry(
-            config=RequestConfig(method=HttpMethod.GET, url=url, timeout=DEFAULT_API_TIMEOUT),
-            response_handler=EvalInfoResponseHandler,
-        )
-
-        template_id = template_details["id"]
-        required_keys = template_details["config"]["required_keys"]
+        # Custom evals have eval_id=0; use the UUID from get-evals directly
+        # to avoid hitting /eval/0/ which may not resolve correctly.
+        is_custom_eval = eval_id == 0
+        if is_custom_eval and matched_eval:
+            template_id = matched_eval.get("id", None)
+            cfg = matched_eval.get("config") or {}
+            required_keys = cfg.get("requiredKeys") or cfg.get("required_keys") or []
+            if not template_id:
+                raise DatasetValidationError(
+                    f"Custom eval '{eval_template}' has no template UUID. Please check the eval configuration."
+                )
+        else:
+            url = f"{self._base_url}/sdk/api/v1/eval/{eval_id}/"
+            template_details = self.request_with_retry(
+                config=RequestConfig(method=HttpMethod.GET, url=url, timeout=DEFAULT_API_TIMEOUT),
+                response_handler=EvalInfoResponseHandler,
+            )
+            template_id = template_details["id"]
+            required_keys = template_details["config"]["required_keys"]
 
         mapping = {}
 

--- a/typescript/futureagi/src/datasets/dataset.ts
+++ b/typescript/futureagi/src/datasets/dataset.ts
@@ -607,23 +607,36 @@ export class Dataset extends APIKeyAuth {
             throw new DatasetValidationError(`Unknown or unsupported evaluation template: ${evalTemplate}`);
         }
 
-        const evalId = matchedListItem.eval_id || matchedListItem.evalId || matchedListItem.id;
-        if (!evalId) {
+        // Resolve eval_id — use evalId/eval_id first, fall back to id (UUID)
+        const candidateId = matchedListItem.eval_id ?? matchedListItem.evalId ?? matchedListItem.id;
+        if (candidateId === undefined || candidateId === null) {
             throw new DatasetError(`Failed to determine eval_id for template '${evalTemplate}'.`);
         }
 
-        // Now fetch detailed info for this template to obtain template_id & required_keys
-        const templateDetail = await this.request<any>(
-            {
-                method: HttpMethod.GET,
-                url: `${this._baseUrl}/${Routes.evaluate_template.replace('{eval_id}', evalId)}`,
-                timeout: DEFAULT_API_TIMEOUT,
-            },
-            EvalInfoResponseHandler
-        ) as Record<string, any>;
+        const isCustomEval = candidateId === 0;
+        let templateId: string;
+        let requiredKeys: string[];
 
-        const templateId = templateDetail.id;
-        const requiredKeys: string[] = templateDetail.config?.required_keys || [];
+        if (isCustomEval && matchedListItem.id) {
+            // Custom evals have evalId=0. Use UUID and config from get-evals directly
+            // instead of hitting /eval/0/ which won't resolve.
+            templateId = matchedListItem.id;
+            const cfg = matchedListItem.config || {};
+            requiredKeys = cfg.requiredKeys || cfg.required_keys || [];
+        } else {
+            // Built-in evals: fetch detailed info from /eval/{eval_id}/
+            const templateDetail = await this.request<any>(
+                {
+                    method: HttpMethod.GET,
+                    url: `${this._baseUrl}/${Routes.evaluate_template.replace('{eval_id}', String(candidateId))}`,
+                    timeout: DEFAULT_API_TIMEOUT,
+                },
+                EvalInfoResponseHandler
+            ) as Record<string, any>;
+
+            templateId = templateDetail.id;
+            requiredKeys = templateDetail.config?.required_keys || [];
+        }
 
         if (!templateId) {
             throw new DatasetError(`template_id not found for evaluation template '${evalTemplate}'.`);


### PR DESCRIPTION
## Description

Fixes custom eval resolution when `evalId=0` in the dataset `add_evaluation` flow (TH-3610). Applied to both Python and TypeScript SDKs.

### Problem
Custom evals created in the dashboard have `evalId=0`. Both SDKs treated `0` as falsy, raising "Unknown template" even though the eval was found. Additionally, hitting `/eval/0/` doesn't resolve correctly for custom evals.

### Fix (Python)
- Changed `if not eval_id` to `if eval_id is None` so `0` is no longer treated as "not found"
- For custom evals (`eval_id == 0`), bypass `/eval/{id}/` and use UUID + requiredKeys directly from get-evals response
- Handle both camelCase (`requiredKeys`) and snake_case (`required_keys`) from config

### Fix (TypeScript)
- Changed `||` to `??` (nullish coalescing) so `0` is not treated as falsy
- Same custom eval path: for `candidateId === 0`, reads UUID and config from get-evals directly
- Handles both `cfg.requiredKeys` and `cfg.required_keys` from response
- Uses `String(candidateId)` for URL interpolation with numeric IDs

## Files Changed
- `python/fi/datasets/dataset.py` — Python custom eval resolution
- `typescript/futureagi/src/datasets/dataset.ts` — TypeScript custom eval resolution

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)