### PR TITLE
fix(datasets): stop orphan datasets + exact by-name resolution (0.6.14)

### DIFF
--- a/python/fi/__init__.py
+++ b/python/fi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.1"
+__version__ = "0.6.14"
 
 # Allow sibling `fi.*` packages (notably `fi.evals` shipped from the
 # ai-evaluation repo) to extend this namespace when both are installed.

--- a/python/fi/api/auth.py
+++ b/python/fi/api/auth.py
@@ -15,7 +15,7 @@ from fi.utils.constants import (
     DEFAULT_TIMEOUT,
     SECRET_KEY_ENVVAR_NAME,
 )
-from fi.utils.errors import MissingAuthError, DatasetNotFoundError
+from fi.utils.errors import MissingAuthError
 from fi.utils.executor import BoundedExecutor
 from fi.utils.utils import ApiKeyName
 
@@ -71,7 +71,13 @@ class HttpClient:
         config: RequestConfig,
         response_handler: Optional[ResponseHandler[T, U]] = None,
     ) -> Union[Response, T]:
-        """Make an HTTP request with retries and response handling"""
+        """Make an HTTP request, retrying only transport-level failures.
+
+        The network round-trip is the only thing retried. Response parsing runs
+        once, after the loop, so a parse/deserialization error (or an HTTP error
+        status) never re-sends the request — retrying a non-idempotent POST on a
+        parse failure silently duplicates server-side writes.
+        """
 
         url = config.url
         headers = {**self._default_headers, **(config.headers or {})}
@@ -80,6 +86,7 @@ class HttpClient:
         timeout = config.timeout or self._default_timeout
         files = config.files or {}
         data = config.data or {}
+        response: Optional[Response] = None
         for attempt in range(config.retry_attempts):
             try:
                 response = self._session.request(
@@ -92,17 +99,15 @@ class HttpClient:
                     files=files,
                     timeout=timeout,
                 ).result()
-
-                if response_handler:
-                    return response_handler.parse(response=response)
-                return response
-
-            except Exception as e:
-                if isinstance(e, DatasetNotFoundError):
-                    raise e
+                break
+            except Exception:
                 if attempt == config.retry_attempts - 1:
-                    raise e
+                    raise
                 time.sleep(config.retry_delay)
+
+        if response_handler:
+            return response_handler.parse(response=response)
+        return response
 
     def close(self):
         """Close the client session"""

--- a/python/fi/datasets/dataset.py
+++ b/python/fi/datasets/dataset.py
@@ -3,7 +3,7 @@ import re
 from typing import Any, Dict, List, Optional, Union
 import time
 import logging
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 import pandas as pd
 from requests import Response
@@ -96,11 +96,23 @@ class DatasetResponseHandler(ResponseHandler[DatasetConfig, DatasetTable]):
         )
 
     @classmethod
-    def _parse_dataset_names(cls, data: Dict[str, Any]) -> DatasetConfig:
-        """Parses the response from the get-datasets-names endpoint."""
+    def _parse_dataset_names(cls, data: Dict[str, Any], response: Response) -> DatasetConfig:
+        """Parses the response from the get-datasets-names endpoint.
+
+        The endpoint matches ``search_text`` as a substring, so a name that is a
+        prefix of another (``foo`` vs ``foo-bar``) can return several rows. By-name
+        lookup is exact by contract, so resolve against the exact requested name
+        rather than trusting the server to return a single fuzzy match.
+        """
         datasets = data["result"]["datasets"]
         if not datasets:
             raise DatasetNotFoundError("No dataset found matching the criteria.")
+        requested_name = parse_qs(urlparse(response.url).query).get("search_text", [None])[0]
+        if requested_name is not None:
+            exact = [d for d in datasets if str(cls._get(d, "name")) == requested_name]
+            if not exact:
+                raise DatasetNotFoundError(f"No dataset named '{requested_name}' found.")
+            datasets = exact
         if len(datasets) > 1:
             raise ValueError("Multiple datasets found. Please specify a dataset name.")
         dataset = datasets[0]
@@ -177,7 +189,7 @@ class DatasetResponseHandler(ResponseHandler[DatasetConfig, DatasetTable]):
         parsed_path = urlparse(response.url).path
 
         if parsed_path.endswith(Routes.dataset_names.value):
-            return cls._parse_dataset_names(data)
+            return cls._parse_dataset_names(data, response)
 
         if Routes.dataset_table.value.split("/")[-2] in parsed_path:
             return cls._parse_dataset_table(data, response)
@@ -974,7 +986,9 @@ class Dataset(APIKeyAuth):
         while retries < max_retries:
             try:
                 return self.request(config=config, response_handler=response_handler)
-            except (ConnectionError, Timeout, ServerError, ServiceUnavailableError) as e:
+            except (ConnectionError, Timeout) as e:
+                # Transport-level only. 5xx/parse errors must not re-send a
+                # non-idempotent POST (would duplicate server-side writes).
                 last_exception = e
                 retries += 1
                 if retries >= max_retries:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "futureagi"
-version = "0.6.13"
+version = "0.6.14"
 description = "We help GenAI teams maintain high-accuracy for their Models in production."
 authors = ["Future AGI <no-reply@futureagi.com>"]
 readme = "README.md"

--- a/python/tests/test_dataset_sdk_hardening.py
+++ b/python/tests/test_dataset_sdk_hardening.py
@@ -1,0 +1,125 @@
+"""Regression tests for the dataset SDK request/parse hardening.
+
+These pin two fixes and are written to fail if either is reverted:
+
+- A parse/deserialization error on a 2xx response must NOT re-send the request.
+  Retrying a non-idempotent POST on a parse failure silently creates orphan
+  datasets server-side.
+- By-name lookup must resolve the EXACT name. The backend matches ``search_text``
+  as a substring, so a prefix-colliding name must not blow up with "Multiple
+  datasets found".
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from requests import Response
+
+from fi.api.auth import APIKeyAuth, ResponseHandler
+from fi.api.types import HttpMethod, RequestConfig
+from fi.datasets.dataset import DatasetResponseHandler
+from fi.utils.errors import DatasetNotFoundError
+
+UUID_FOO = "11111111-1111-1111-1111-111111111111"
+UUID_FOOBAR = "22222222-2222-2222-2222-222222222222"
+
+
+def _mock_response(data, status_code=200, url="http://api.test/"):
+    resp = MagicMock(spec=Response)
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    resp.json.return_value = data
+    resp.text = json.dumps(data)
+    resp.url = url
+    return resp
+
+
+def _client_with_session(result=None, side_effect=None):
+    client = APIKeyAuth(fi_api_key="k", fi_secret_key="s")
+    client._session = MagicMock()
+    future = client._session.request.return_value
+    if side_effect is not None:
+        future.result.side_effect = side_effect
+    else:
+        future.result.return_value = result
+    return client
+
+
+class _BrokenHandler(ResponseHandler):
+    """Simulates a contract-mismatch parse error on an otherwise-successful 2xx."""
+
+    @classmethod
+    def _parse_success(cls, response):
+        raise KeyError("datasetId")
+
+    @classmethod
+    def _handle_error(cls, response):
+        raise RuntimeError("unexpected error path")
+
+
+# --------------------------------------------------------------------------
+# A non-idempotent POST must not be re-sent on a parse error
+# --------------------------------------------------------------------------
+
+def test_post_not_resent_when_parsing_a_successful_response_fails():
+    client = _client_with_session(result=_mock_response({"result": {}}, 200))
+    config = RequestConfig(
+        method=HttpMethod.POST,
+        url="http://api.test/create-empty-dataset/",
+        json={"new_dataset_name": "x"},
+    )
+
+    with pytest.raises(KeyError):
+        client.request(config=config, response_handler=_BrokenHandler)
+
+    # The POST reached the server once; the parse failure must not retry it.
+    assert client._session.request.call_count == 1
+
+
+def test_transport_failures_are_still_retried():
+    client = _client_with_session(side_effect=ConnectionError("boom"))
+    config = RequestConfig(
+        method=HttpMethod.GET,
+        url="http://api.test/get-datasets/",
+        retry_attempts=3,
+        retry_delay=0,
+    )
+
+    with pytest.raises(ConnectionError):
+        client.request(config=config, response_handler=None)
+
+    assert client._session.request.call_count == 3
+
+
+# --------------------------------------------------------------------------
+# By-name lookup resolves the exact name, not a fuzzy prefix match
+# --------------------------------------------------------------------------
+
+def _names_response(datasets, search_text):
+    url = f"http://api.test/model-hub/develops/get-datasets-names/?search_text={search_text}"
+    data = {"result": {"datasets": datasets}}
+    return data, _mock_response(data, 200, url=url)
+
+
+def test_by_name_resolves_exact_match_among_prefix_collision():
+    datasets = [
+        {"name": "foo", "dataset_id": UUID_FOO, "model_type": "GenerativeLLM"},
+        {"name": "foo-bar", "dataset_id": UUID_FOOBAR, "model_type": "GenerativeLLM"},
+    ]
+    data, resp = _names_response(datasets, "foo")
+
+    config = DatasetResponseHandler._parse_dataset_names(data, resp)
+
+    assert str(config.id) == UUID_FOO
+    assert config.name == "foo"
+
+
+def test_by_name_raises_not_found_when_only_fuzzy_matches_exist():
+    datasets = [
+        {"name": "foo-bar", "dataset_id": UUID_FOOBAR, "model_type": "GenerativeLLM"},
+    ]
+    data, resp = _names_response(datasets, "foo")
+
+    with pytest.raises(DatasetNotFoundError):
+        DatasetResponseHandler._parse_dataset_names(data, resp)


### PR DESCRIPTION
## Summary

Fully closes the dataset SDK contract tickets. The camelCase parser fix (TH-6558) already landed on `dev`; this PR adds the two secondary fixes that fix didn't cover, and bumps the release to `0.6.14`.

- **No more orphan datasets on create.** `HttpClient.request` now parses the response **once, outside the retry loop**, and retries only transport-level failures. A parse/deserialization error on a `2xx` response no longer re-sends the request — retrying a non-idempotent POST on a parse failure was silently creating orphan datasets and surfacing a false `"already exists"`. Also dropped `ServerError`/`ServiceUnavailableError` from `Dataset.request_with_retry` so a `5xx` cannot re-send a POST either. (TH-6527)
- **By-name lookup is now exact.** `_parse_dataset_names` resolves against the exact requested name (from the request's `search_text`) instead of trusting the server's substring match. Prefix-colliding names (`foo` vs `foo-bar`) no longer raise `"Multiple datasets found"`; a name with no exact match raises `DatasetNotFoundError`. (TH-6533)
- Bump `0.6.13` → `0.6.14` (also fixes the stale `__version__ = "0.0.1"`).

Closes TH-6527, TH-6533. TH-6558 (camelCase parsers) already fixed on `dev` and ships in this release.

## Behavior change (intentional)

Retry is now **transport-only** (`ConnectionError`/`Timeout`). There is no `5xx` auto-retry anywhere. `HttpClient.request` is shared by `datasets`/`prompt`/`queues`/`kb`/`annotations`, so all of them lose `5xx` auto-retry — this is deliberate: retrying a non-idempotent write on a `5xx` is what duplicates data. Reads are unaffected on the happy path.

## Testing

- New `test_dataset_sdk_hardening.py` (4 unit tests). **Revert-proven**: the 3 behavioral tests fail if either fix is reverted (verified via stash-revert).
- Full suite: **73 passed**.
- Verified live against `dev.api.futureagi.com`:
  - Full lifecycle: create → by-name add-rows (server `row_count` 0→2) → by-name get-config → by-name delete.
  - **Prefix collision**: server returned both `foo` and `foo-extra`; SDK resolved the exact name (old SDK raised `ValueError`).
  - **Deep table parse**: DataFrame `[question, answer]`, 2 rows, cell values `{q1, q2}` — exercises the row/cell parser.
  - Cross-module reads (shared retry path): `prompt.list_templates`, `annotations.list_projects`, `queues.list_queues`.
  - Zero orphan datasets left behind.

The orphan/retry fix cannot be reproduced live (the primary camelCase fix masks it — parsing no longer fails), so it is unit-pinned instead.